### PR TITLE
Generational References V2: Add missed word

### DIFF
--- a/src/blog/vision/generational-references-v2.vmd
+++ b/src/blog/vision/generational-references-v2.vmd
@@ -166,7 +166,7 @@ void __check(GenerationalReference genRef) {
 ```
 
 
-It's as we're saying:
+It's as if we're saying:
 
 > *"Hello! I'm looking for the 11th inhabitant of this house, are they still around?"*
 


### PR DESCRIPTION
When compared with version 1 of the article, it seemed that "if" was missed.